### PR TITLE
Feature/T32 pick bans data grid ddragon version dependent

### DIFF
--- a/client/src/components/Tournament/ChampsDataGrid.js
+++ b/client/src/components/Tournament/ChampsDataGrid.js
@@ -42,7 +42,7 @@ export default function ChampsDataGrid({ pickbans }) {
             <Grid item xs={12}>
                 <Paper className={classes.paper}>
                 <div className={classes.title}>{pickbans.NumberGames} Games Played</div>
-                <div className={classes.blurb}>{pickbans.ChampsWithPresence} / {Object.keys(ChampById).length} Champions Picked or Banned</div>
+                <div className={classes.blurb}>{pickbans.ChampsWithPresence} / {pickbans.PickBanList.length} Champions Picked or Banned</div>
                 <DataGrid
                     id="gridContainer"
                     width="inherit"

--- a/server/services/ddragonVersion.js
+++ b/server/services/ddragonVersion.js
@@ -1,9 +1,4 @@
 import axios from "axios";
-import { CACHE_KEYS } from "../functions/apiV1/dependencies/cacheKeys";
-import { GLOBAL_CONSTS } from "../functions/apiV1/dependencies/global";
-
-const redis = require('redis');
-const cache = (process.env.NODE_ENV === 'production') ? redis.createClient(process.env.REDIS_URL) : redis.createClient(process.env.REDIS_PORT);
 
 /**
  * Gets the DDragon version of the LoL patch based on: https://ddragon.leagueoflegends.com/api/versions.json
@@ -15,20 +10,16 @@ export const getDDragonVersion = (patch=null) => {
         .then((res) => {
             const versionList = res.data;
             if (patch) {
-                for (let i = 0; i < versionList.length; ++i) {
-                    const DDragonVersion = versionList[i];
+                for (const DDragonVersion of versionList) {
                     if (DDragonVersion.includes(patch)) {
                         resolve(DDragonVersion);
+                        return;
                     }
                 }
             }
-            const cacheKey = CACHE_KEYS.LATEST_PATCH;
-            cache.get(cacheKey, (err, data) => {
-                if (err) { console.error(err); reject(err); return; }
-                else if (data) { resolve(JSON.parse(data)); return; }
-                cache.set(cacheKey, JSON.stringify(versionList[0]), 'EX', GLOBAL_CONSTS.TTL_DURATION);
+            else {
                 resolve(versionList[0]);    // Return latest as default
-            });
+            }
         }).catch((err) => {
             reject(err);
         });


### PR DESCRIPTION
- So that if someone views an older split, it doesn't display champs that weren't released at that time.
- Also did a small cleanup on the functions