### PR TITLE
Feature/t51 refactor multiple service calls square components

### DIFF
--- a/client/src/components/ChampionSquare.js
+++ b/client/src/components/ChampionSquare.js
@@ -74,7 +74,7 @@ export default function ChampionSquare({
     getChampName(id).then((data) => { setName(data); });
     getCurrentVersion().then((data) => { setCurrentVersion(data); });
     getVersionByPatch(patch).then((data) => { setPatchVersion(data); });
-  }, []);
+  }, [id, patch]);
   const classes = useStyles();
 
   const ddragonVersion = (!patch) ? ((!version) ? currentVersion : version) : patchVersion;

--- a/client/src/components/ChampionSquare.js
+++ b/client/src/components/ChampionSquare.js
@@ -1,5 +1,5 @@
 // npm modules
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 // MUI
 import { makeStyles } from '@material-ui/core/styles';
 // Static
@@ -69,6 +69,8 @@ export default function ChampionSquare({
 
   const urlId = getChampUrlId(id);
   const name = getChampName(id);
+  const currentVersion = getCurrentVersion();
+  const patchVersion = getVersionByPatch(patch);
   const ddragonVersion = (!patch) ? ((!version) ? currentVersion : version) : patchVersion;
   const urlImg = `https://ddragon.leagueoflegends.com/cdn/${ddragonVersion}/img/champion/${urlId}.png`;
 

--- a/client/src/components/ChampionSquare.js
+++ b/client/src/components/ChampionSquare.js
@@ -5,8 +5,10 @@ import { makeStyles } from '@material-ui/core/styles';
 // Static
 import NoImage from '../static/no-image.png';
 import {
-  getChampIds,
-  getVersionList
+  getChampName,
+  getChampUrlId,
+  getCurrentVersion,
+  getVersionByPatch,
 } from '../service/StaticCalls';
 
 const useStyles = makeStyles((theme) => ({
@@ -63,52 +65,19 @@ export default function ChampionSquare({
   width = 30,
   height = 30,
 }) {
-  const [versionList, setVersionList] = useState(null);
-  const [champByIds, setChampByIds] = useState(null);
-  const classes = useStyles();
+  const [urlId, setUrlId] = useState(null);
+  const [name, setName] = useState(null);
+  const [currentVersion, setCurrentVersion] = useState(null);
+  const [patchVersion, setPatchVersion] = useState(null);
   useEffect(() => {
-    getVersionList().then((data) => { setVersionList(data); });
-    getChampIds().then((data) => { setChampByIds(data); });
+    getChampUrlId(id).then((data) => { setUrlId(data); });
+    getChampName(id).then((data) => { setName(data); });
+    getCurrentVersion().then((data) => { setCurrentVersion(data); });
+    getVersionByPatch(patch).then((data) => { setPatchVersion(data); });
   }, []);
+  const classes = useStyles();
 
-  const getChampUrlId = (id) => {
-    if (!champByIds) return null;
-    if (!(id in champByIds)) {
-      return id;
-    }
-  
-    return champByIds[id]['id'];
-  }
-  
-  const getChampName = (id) => {
-    if (!champByIds) return null;
-    if (!(id in champByIds)) {
-      return id;
-    }
-    return champByIds[id]['name'];
-  }
-  
-  const getCurrentVersion = () => {
-    return (versionList) ? versionList[0] : null;
-  }
-  
-  const getVersionByPatch = (patch) => {
-    if (!versionList) return null;
-    if (patch) {
-      for (const DDragonVersion of versionList) {
-        if (DDragonVersion.includes(patch)) {
-          return DDragonVersion;
-        }
-      }
-    }
-    return versionList[0]; // Default latest patch
-  }
-
-  const urlId = getChampUrlId(id);
-  const name = getChampName(id);
-  const ddragonVersion = (!patch) ?
-    ((!version) ? getCurrentVersion() : version) :
-    getVersionByPatch(patch);
+  const ddragonVersion = (!patch) ? ((!version) ? currentVersion : version) : patchVersion;
   const urlImg = `https://ddragon.leagueoflegends.com/cdn/${ddragonVersion}/img/champion/${urlId}.png`;
 
   const imgComponent = (!urlId || !ddragonVersion) ? 

--- a/client/src/components/ChampionSquare.js
+++ b/client/src/components/ChampionSquare.js
@@ -65,18 +65,10 @@ export default function ChampionSquare({
   width = 30,
   height = 30,
 }) {
-  const [urlId, setUrlId] = useState(null);
-  const [name, setName] = useState(null);
-  const [currentVersion, setCurrentVersion] = useState(null);
-  const [patchVersion, setPatchVersion] = useState(null);
-  useEffect(() => {
-    getChampUrlId(id).then((data) => { setUrlId(data); });
-    getChampName(id).then((data) => { setName(data); });
-    getCurrentVersion().then((data) => { setCurrentVersion(data); });
-    getVersionByPatch(patch).then((data) => { setPatchVersion(data); });
-  }, [id, patch]);
   const classes = useStyles();
 
+  const urlId = getChampUrlId(id);
+  const name = getChampName(id);
   const ddragonVersion = (!patch) ? ((!version) ? currentVersion : version) : patchVersion;
   const urlImg = `https://ddragon.leagueoflegends.com/cdn/${ddragonVersion}/img/champion/${urlId}.png`;
 

--- a/client/src/components/ItemSquare.js
+++ b/client/src/components/ItemSquare.js
@@ -68,7 +68,7 @@ export default function ItemSquare({
   useEffect(() => {
     getCurrentVersion().then((data) => { setCurrentVersion(data); });
     getVersionByPatch(patch).then((data) => { setPatchVersion(data); });
-  }, []);
+  }, [patch]);
   const classes = useStyles();
 
   const ddragonVersion = (!patch) ? ((!version) ? currentVersion : version) : patchVersion;

--- a/client/src/components/ItemSquare.js
+++ b/client/src/components/ItemSquare.js
@@ -3,7 +3,10 @@ import React, { useEffect, useState } from 'react';
 // MUI
 import { makeStyles } from '@material-ui/core/styles';
 // Static
-import { getCurrentVersion, getVersionByPatch, getVersionList } from '../service/StaticCalls';
+import { 
+  getCurrentVersion,
+  getVersionByPatch,
+} from '../service/StaticCalls';
 import NoImage from '../static/no-image.png';
 
 const useStyles = makeStyles((theme) => ({

--- a/client/src/components/ItemSquare.js
+++ b/client/src/components/ItemSquare.js
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from 'react';
 // MUI
 import { makeStyles } from '@material-ui/core/styles';
 // Static
-import { getVersionList } from '../service/StaticCalls';
+import { getCurrentVersion, getVersionByPatch, getVersionList } from '../service/StaticCalls';
 import NoImage from '../static/no-image.png';
 
 const useStyles = makeStyles((theme) => ({
@@ -60,32 +60,15 @@ export default function ItemSquare({
   width = 30,
   height = 30,
 }) {
-  const [versionList, setVersionList] = useState(null);
-  const classes = useStyles();
+  const [currentVersion, setCurrentVersion] = useState(null);
+  const [patchVersion, setPatchVersion] = useState(null);
   useEffect(() => {
-    getVersionList().then((data) => { setVersionList(data); });
+    getCurrentVersion().then((data) => { setCurrentVersion(data); });
+    getVersionByPatch(patch).then((data) => { setPatchVersion(data); });
   }, []);
+  const classes = useStyles();
 
-  const getCurrentVersion = () => {
-    return (versionList) ? versionList[0] : null;
-  }
-  
-  const getVersionByPatch = (patch) => {
-    if (!versionList) return null;
-    if (patch) {
-      for (const DDragonVersion of versionList) {
-        if (DDragonVersion.includes(patch)) {
-          return DDragonVersion;
-        }
-      }
-    }
-    return versionList[0]; // Default latest patch
-  }
-
-  const ddragonVersion = (!patch) ?
-    ((!version) ? getCurrentVersion() : version) :
-    getVersionByPatch(patch);
-
+  const ddragonVersion = (!patch) ? ((!version) ? currentVersion : version) : patchVersion;
   const imgUrl = `https://ddragon.leagueoflegends.com/cdn/${ddragonVersion}/img/item/${id}.png`;
   // since we can get itemIds that = 0, we want to render a blank square
   const imgComponent = (!id || !ddragonVersion || id === 0) ? 

--- a/client/src/components/ItemSquare.js
+++ b/client/src/components/ItemSquare.js
@@ -63,14 +63,10 @@ export default function ItemSquare({
   width = 30,
   height = 30,
 }) {
-  const [currentVersion, setCurrentVersion] = useState(null);
-  const [patchVersion, setPatchVersion] = useState(null);
-  useEffect(() => {
-    getCurrentVersion().then((data) => { setCurrentVersion(data); });
-    getVersionByPatch(patch).then((data) => { setPatchVersion(data); });
-  }, [patch]);
   const classes = useStyles();
 
+  const currentVersion = getCurrentVersion();
+  const patchVersion = getVersionByPatch(patch);
   const ddragonVersion = (!patch) ? ((!version) ? currentVersion : version) : patchVersion;
   const imgUrl = `https://ddragon.leagueoflegends.com/cdn/${ddragonVersion}/img/item/${id}.png`;
   // since we can get itemIds that = 0, we want to render a blank square

--- a/client/src/components/ItemSquare.js
+++ b/client/src/components/ItemSquare.js
@@ -1,5 +1,5 @@
 // npm modules
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 // MUI
 import { makeStyles } from '@material-ui/core/styles';
 // Static

--- a/client/src/components/Markup.js
+++ b/client/src/components/Markup.js
@@ -1,13 +1,23 @@
 import React from 'react';
+import { 
+  isSessionDataLoaded,
+  setSessionDataChamps,
+  setSessionDataSpells,
+  setSessionDataVersions
+} from '../service/StaticCalls';
 // Components
 import Loading from './Loading';
 
 // If data hasn't loaded yet, it will continue to remain as 'null'.
 // Need a loading status as this is happening
 export default function Markup({ data, code, dataComponent }) {
-  let markup = null;
+  // Set Session data on Markup
+  setSessionDataVersions();
+  setSessionDataChamps();
+  setSessionDataSpells();
 
-  if (!data && (!code || code === 200)) {
+  let markup = null;
+  if ((!data || isSessionDataLoaded()) && (!code || code === 200)) {
     markup = (<Loading />);
   } else if (data) {
     markup = (dataComponent);

--- a/client/src/components/SpellSquare.js
+++ b/client/src/components/SpellSquare.js
@@ -64,16 +64,11 @@ export default function SpellSquare({
   width = 30,
   height = 30,
 }) {
-  const [urlId, setUrlId] = useState(null);
-  const [currentVersion, setCurrentVersion] = useState(null);
-  const [patchVersion, setPatchVersion] = useState(null);
-  useEffect(() => {
-    getSpellUrlId(id).then((data) => { setUrlId(data); });
-    getCurrentVersion().then((data) => { setCurrentVersion(data); });
-    getVersionByPatch(patch).then((data) => { setPatchVersion(data); });
-  }, [id, patch]);
   const classes = useStyles();
 
+  const urlId = getSpellUrlId(id);
+  const currentVersion = getCurrentVersion();
+  const patchVersion = getVersionByPatch(patch);
   const ddragonVersion = (!patch) ? ((!version) ? currentVersion : version) : patchVersion;
   const imgUrl = `https://ddragon.leagueoflegends.com/cdn/${ddragonVersion}/img/spell/${urlId}.png`;
 

--- a/client/src/components/SpellSquare.js
+++ b/client/src/components/SpellSquare.js
@@ -71,7 +71,7 @@ export default function SpellSquare({
     getSpellUrlId(id).then((data) => { setUrlId(data); });
     getCurrentVersion().then((data) => { setCurrentVersion(data); });
     getVersionByPatch(patch).then((data) => { setPatchVersion(data); });
-  }, []);
+  }, [id, patch]);
   const classes = useStyles();
 
   const ddragonVersion = (!patch) ? ((!version) ? currentVersion : version) : patchVersion;

--- a/client/src/components/SpellSquare.js
+++ b/client/src/components/SpellSquare.js
@@ -5,8 +5,9 @@ import { makeStyles } from '@material-ui/core/styles';
 // Static
 import NoImage from '../static/no-image.png';
 import {
-  getSpellIds,
-  getVersionList
+  getCurrentVersion,
+  getSpellUrlId,
+  getVersionByPatch,
 } from '../service/StaticCalls';
 
 const useStyles = makeStyles((theme) => ({
@@ -63,42 +64,17 @@ export default function SpellSquare({
   width = 30,
   height = 30,
 }) {
-  const [versionList, setVersionList] = useState(null);
-  const [spellByIds, setSpellByIds] = useState(null);
-  const classes = useStyles();
+  const [urlId, setUrlId] = useState(null);
+  const [currentVersion, setCurrentVersion] = useState(null);
+  const [patchVersion, setPatchVersion] = useState(null);
   useEffect(() => {
-    getVersionList().then((data) => { setVersionList(data); });
-    getSpellIds().then((data) => { setSpellByIds(data); });
+    getSpellUrlId(id).then((data) => { setUrlId(data); });
+    getCurrentVersion().then((data) => { setCurrentVersion(data); });
+    getVersionByPatch(patch).then((data) => { setPatchVersion(data); });
   }, []);
+  const classes = useStyles();
 
-  const getCurrentVersion = () => {
-    return (versionList) ? versionList[0] : null;
-  }
-  
-  const getVersionByPatch = (patch) => {
-    if (!versionList) { return null; }
-    if (patch) {
-      for (const DDragonVersion of versionList) {
-        if (DDragonVersion.includes(patch)) {
-          return DDragonVersion;
-        }
-      }
-    }
-    return versionList[0]; // Default latest patch
-  }
-  
-  const getSpellUrlId = (id) => {
-    if (!spellByIds) { return null; }
-    if (!(id in spellByIds)) {
-      return id;
-    }
-    return spellByIds[id]['id'];
-  }
-
-  const urlId = getSpellUrlId(id);
-  const ddragonVersion = (!patch) ?
-    ((!version) ? getCurrentVersion() : version) :
-    getVersionByPatch(patch);
+  const ddragonVersion = (!patch) ? ((!version) ? currentVersion : version) : patchVersion;
   const imgUrl = `https://ddragon.leagueoflegends.com/cdn/${ddragonVersion}/img/spell/${urlId}.png`;
 
   const imgComponent = (!urlId || !ddragonVersion) ? 

--- a/client/src/components/SpellSquare.js
+++ b/client/src/components/SpellSquare.js
@@ -1,5 +1,5 @@
 // npm modules
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 // MUI
 import { makeStyles } from '@material-ui/core/styles';
 // Static

--- a/client/src/components/SpellSquare.js
+++ b/client/src/components/SpellSquare.js
@@ -5,8 +5,8 @@ import { makeStyles } from '@material-ui/core/styles';
 // Static
 import NoImage from '../static/no-image.png';
 import {
-  getCurrentVersion,
   getSpellUrlId,
+  getCurrentVersion,
   getVersionByPatch,
 } from '../service/StaticCalls';
 

--- a/client/src/service/StaticCalls.js
+++ b/client/src/service/StaticCalls.js
@@ -5,18 +5,18 @@ const CHAMPS = 'champs';
 const SPELLS = 'spells';
 const VERSIONS = 'versions';
 
+const sessionKey = {
+  [CHAMPS]: 'doowanstats_champIds',
+  [SPELLS]: 'doowanstats_spellIds',
+  [VERSIONS]: 'doowanstats_versions',
+}
+
 /**
  * Helper function to call GET request of static data
  * @param {string} apiType  API URL call in string
  * @returns Promise
  */
-const getStaticData = (apiType) => {
-  const sessionKey = {
-    [CHAMPS]: 'doowanstats_champIds',
-    [SPELLS]: 'doowanstats_spellIds',
-    [VERSIONS]: 'doowanstats_versions',
-  }
-
+const setSessionData = (apiType) => {
   return new Promise((resolve, reject) => {
     const data = JSON.parse(window.sessionStorage.getItem(sessionKey[apiType]));
 
@@ -37,11 +37,46 @@ const getStaticData = (apiType) => {
 
 /**
  * 
+ * @param {string} apiType 
+ * @returns Object
+ */
+const getSessionData = (apiType) => {
+  return JSON.parse(window.sessionStorage.getItem(sessionKey[apiType]));
+}
+
+/**
+ * Sets session data for the map object of Champs
+ * @returns void
+ */
+export const setSessionDataChamps = () => {
+  setSessionData(VERSIONS);
+  setSessionData(CHAMPS);
+}
+
+/**
+ * Sets session data for the map object of Spells
+ * @returns void
+ */
+export const setSessionDataSpells = () => {
+  setSessionData(VERSIONS);
+  setSessionData(SPELLS);
+}
+
+/**
+ * Sets session data for list of Versions
+ * @returns void
+ */
+export const setSessionDataVersions = () => {
+  setSessionData(VERSIONS);
+}
+
+/**
+ * 
  * @param {number} id
  * @returns Promise
  */
-export const getChampUrlId = async (id) => {
-  const champByIds = await getStaticData(CHAMPS);
+export const getChampUrlId = (id) => {
+  const champByIds = getSessionData(CHAMPS);
 
   if (!champByIds) return null;
   if (!(id in champByIds)) {
@@ -55,8 +90,8 @@ export const getChampUrlId = async (id) => {
  * @param {number} id
  * @returns Promise
  */
-export const getChampName = async (id) => {
-  const champByIds = await getStaticData(CHAMPS);
+export const getChampName = (id) => {
+  const champByIds = getSessionData(CHAMPS);
 
   if (!champByIds) return null;
   if (!(id in champByIds)) {
@@ -70,8 +105,8 @@ export const getChampName = async (id) => {
  * @param {number} id 
  * @returns Promise
  */
-export const getSpellUrlId = async (id) => {
-  const spellByIds = await getStaticData(SPELLS);
+export const getSpellUrlId = (id) => {
+  const spellByIds = getSessionData(SPELLS);
 
   if (!spellByIds) { return null; }
   if (!(id in spellByIds)) {
@@ -84,8 +119,8 @@ export const getSpellUrlId = async (id) => {
  * 
  * @returns Promise
  */
-export const getCurrentVersion = async () => {
-  const versionList = await getStaticData(VERSIONS);
+export const getCurrentVersion = () => {
+  const versionList = getSessionData(VERSIONS);
 
   return (versionList) ? versionList[0] : null;
 }
@@ -95,8 +130,8 @@ export const getCurrentVersion = async () => {
  * @param {string} patch 
  * @returns Promise
  */
-export const getVersionByPatch = async (patch) => {
-  const versionList = await getStaticData(VERSIONS);
+export const getVersionByPatch = (patch) => {
+  const versionList = getSessionData(VERSIONS);
 
   if (!versionList) return null;
   if (patch) {

--- a/client/src/service/StaticCalls.js
+++ b/client/src/service/StaticCalls.js
@@ -45,11 +45,22 @@ const getSessionData = (apiType) => {
 }
 
 /**
+ * 
+ * @returns boolean
+ */
+export const isSessionDataLoaded = () => {
+  return (
+    JSON.parse(window.sessionStorage.getItem(CHAMPS)) &&
+    JSON.parse(window.sessionStorage.getItem(SPELLS)) &&
+    JSON.parse(window.sessionStorage.getItem(VERSIONS))
+  );
+}
+
+/**
  * Sets session data for the map object of Champs
  * @returns void
  */
 export const setSessionDataChamps = () => {
-  setSessionData(VERSIONS);
   setSessionData(CHAMPS);
 }
 
@@ -58,7 +69,6 @@ export const setSessionDataChamps = () => {
  * @returns void
  */
 export const setSessionDataSpells = () => {
-  setSessionData(VERSIONS);
   setSessionData(SPELLS);
 }
 

--- a/client/src/service/StaticCalls.js
+++ b/client/src/service/StaticCalls.js
@@ -10,7 +10,7 @@ const VERSIONS = 'versions';
  * @param {string} apiType  API URL call in string
  * @returns Promise
  */
-const staticAxiosCall = (apiType) => {
+const getStaticData = (apiType) => {
   const sessionKey = {
     [CHAMPS]: 'doowanstats_champIds',
     [SPELLS]: 'doowanstats_spellIds',
@@ -36,25 +36,75 @@ const staticAxiosCall = (apiType) => {
 }
 
 /**
- * Get ChampIds object
+ * 
+ * @param {number} id
  * @returns Promise
  */
-export const getChampIds = () => {
-  return staticAxiosCall(CHAMPS);
+export const getChampUrlId = async (id) => {
+  const champByIds = await getStaticData(CHAMPS);
+
+  if (!champByIds) return null;
+  if (!(id in champByIds)) {
+    return id;
+  }
+  return champByIds[id]['id'];
 }
 
 /**
- * Get SpellIds object
+ * 
+ * @param {number} id
  * @returns Promise
  */
-export const getSpellIds = () => {
-  return staticAxiosCall(SPELLS);
+export const getChampName = async (id) => {
+  const champByIds = await getStaticData(CHAMPS);
+
+  if (!champByIds) return null;
+  if (!(id in champByIds)) {
+    return id;
+  }
+  return champByIds[id]['name'];
 }
 
 /**
- * Get Versions list
+ * 
+ * @param {number} id 
  * @returns Promise
  */
-export const getVersionList = () => {
-  return staticAxiosCall(VERSIONS);
+export const getSpellUrlId = async (id) => {
+  const spellByIds = await getStaticData(SPELLS);
+
+  if (!spellByIds) { return null; }
+  if (!(id in spellByIds)) {
+    return id;
+  }
+  return spellByIds[id]['id'];
+}
+
+/**
+ * 
+ * @returns Promise
+ */
+export const getCurrentVersion = async () => {
+  const versionList = await getStaticData(VERSIONS);
+
+  return (versionList) ? versionList[0] : null;
+}
+
+/**
+ * 
+ * @param {string} patch 
+ * @returns Promise
+ */
+export const getVersionByPatch = async (patch) => {
+  const versionList = await getStaticData(VERSIONS);
+
+  if (!versionList) return null;
+  if (patch) {
+    for (const DDragonVersion of versionList) {
+      if (DDragonVersion.includes(patch)) {
+        return DDragonVersion;
+      }
+    }
+  }
+  return versionList[0]; // Default latest patch
 }


### PR DESCRIPTION
- Reduced service calls for getting static data of Champions, Items, and Spells
- Functions can now be used outside through export